### PR TITLE
glympse: Add internal temperature reading

### DIFF
--- a/disco/uavpal/bin/uavpal_glympse.sh
+++ b/disco/uavpal/bin/uavpal_glympse.sh
@@ -183,8 +183,13 @@ do
 			signal="$mode/$signalPercentage"
 		fi
 	fi
+	temp=""
+	tempfile="/sys/devices/platform/p7-temperature/iio:device1/in_temp7_p7mu_raw"
+	if [ -f $tempfile ]; then
+		temp=$(cat $tempfile)"°C"
+	fi
 
-	droneLabel="${droneName} (Sig:${signal} Alt:${altitude_rel}m Bat:${bat_percent}%/${bat_volts}V Ltn:${latency}${ztConn})"
+	droneLabel="${droneName} (${signal} ${altitude_rel}m ${bat_volts}V/${bat_percent}% ${temp} ${latency}${ztConn})"
 	ulogger -s -t uavpal_glympse "... updating Glympse label ($(date +%Y-%m-%d-%H:%M:%S)): $droneLabel"
 
 	/data/ftp/uavpal/bin/curl -q -k -H "Content-Type: application/json" -H "Authorization: Bearer ${access_token}" -X POST -d "[[$(date +%s)000,$(gpsDecimal $lat $latdir),$(gpsDecimal $long $longdir),$speed,$heading]]" "https://api.glympse.com/v2/tickets/$ticket/append_location" &


### PR DESCRIPTION
This adds the P7MU temperature reading to the Glympse string. It is the most
sensible internal temperature sensor I could find.

AnthonyH on slack has tested its' limits and found the Chuck starts flashing red at
103 degrees and shuts down at 111.

To make room for this new value in the Glympse string, I have removed the
prefixes for each value. To make the battery reading read more intuitive I
also swapped the positions of battery volt and battery percent.

Here is what the Glympse view looks with temperature added and prefixes kept:
![glympse-prefix](https://user-images.githubusercontent.com/229360/83054502-c91b6680-a052-11ea-8e71-e7a663134e95.png)
Here it is without prefixes:
![glympse-no-prefix](https://user-images.githubusercontent.com/229360/83054515-cde01a80-a052-11ea-8b78-67f2b103be01.png)
And for 4G:
![glympse-no-prefix-4g](https://user-images.githubusercontent.com/229360/83054518-d0427480-a052-11ea-9432-771afa5baf88.png)
