### PR TITLE
add CallMeBot.com support for sending glympse link via mobile transfer

### DIFF
--- a/disco/uavpal/bin/uavpal_globalfunctions.sh
+++ b/disco/uavpal/bin/uavpal_globalfunctions.sh
@@ -76,6 +76,14 @@ send_message()
 		ulogger -s -t uavpal_send_message "... Cannot send message (no connection). Exiting send_message function!"
 		exit 1 # exit function
 	fi
+
+	callmebot_apikey="$(conf_read callmebot)"
+	if [ "$callmebot_apikey" != "XXXXXXXXXXXXXXXX" ]; then
+			msg=$1
+			ulogger -s -t uavpal_send_message "... sending message (via Messenger CallMeBot API)"
+			/data/ftp/uavpal/bin/curl -q -k -G --data-urlencode "text=${msg}" "https://api.callmebot.com/facebook/send.php?apikey=${callmebot_apikey}"
+	fi
+
 	phone_no="$(conf_read phonenumber)"
 	if [ "$phone_no" != "+XXYYYYYYYYY" ]; then
 		if [ ! -f "/tmp/hilink_router_ip" ]; then

--- a/disco/uavpal/conf/callmebot
+++ b/disco/uavpal/conf/callmebot
@@ -1,0 +1,2 @@
+XXXXXXXXXXXXXXXX
+# Enter your CallMeBot API key on the first line. Leave it set to XXXXXXXXXXXXXXXX, if you don't want to use CallMeBot.


### PR DESCRIPTION
I am an iOS user and my operator charges for sending SMS from the card. Logging in to PushBullet via a browser takes a while, so I decided to make it easier for such people by using the CallMeBot.com service.
Of course, you can use it on Android and iOS. We need the Messenger app on the device. :)

Yeap, I also tested it for the microSD card message.
Unfortunately, I don't have a bebop2 to test, but it should work there too. If someone has such a possibility - I would ask for a check.

We need to add this lines to Installation wiki:
## CallMeBot Facebook Messenger
**→ Optional, if you decide not to use CallMeBot Facebook Messenger, you won't need this.**

If you are an iOS user, and you do not want to send a glympse link via SMS or open PushBullet via a browser, it is possible to send messages to Facebook Messenger.

Create a free CallMeBot API Key.
1. Start a Facebook Messenger conversation with [@api.callmebot](https://m.me/api.callmebot). Or click here: [https://m.me/api.callmebot](https://m.me/api.callmebot)
2. Send "**create apikey**" to [@api.callmebot](https://m.me/api.callmebot) (using Facebook Messenger of course)
3. The bot will generate a secure apikey for you.
4. The bot will answer you with your apikey, note it down as we need it later.